### PR TITLE
Fix visual studio compiler errors

### DIFF
--- a/wfmath/const.h
+++ b/wfmath/const.h
@@ -33,7 +33,7 @@
     #error "You are using an older version of MSVC++ with extremely poor"
     #error "template support. Please use at least version 7.0, where the"
     #error "template support is merely bad, or try a different compiler."
-  #else
+  #elif _MSC_VER < 1500
     // The name of this one is somewhat misleading. The problem is,
     // while you can _define_ specializations of template functions,
     // you can't _declare_ them.

--- a/wfmath/int_to_string.cpp
+++ b/wfmath/int_to_string.cpp
@@ -24,13 +24,7 @@ static char* DoIntToString(unsigned long val, char* bufhead)
   return bufhead;
 }
 
-// note that all floating point math is done at compile time
-static const double log_10_of_2 = 0.30102995664;
-static const unsigned ul_max_digits = (unsigned)
-	(8 * sizeof(unsigned long) // number of bits
-	* log_10_of_2 // base 10 vs. base 2 digits
-	+ 1 // log(1) == 0, have to add one for leading digit
-	+ WFMATH_EPSILON); // err on the safe side of roundoff
+static const unsigned long ul_max_digits = (ULONG_MAX >> 32 == 0) ? 10 : 20;
 
 std::string WFMath::IntToString(unsigned long val)
 {


### PR DESCRIPTION
do not use sizeof() in preprocessor
