### PR TITLE
Apple GCC fix.

### DIFF
--- a/wfmath/axisbox.cpp
+++ b/wfmath/axisbox.cpp
@@ -48,7 +48,4 @@ template AxisBox<2> BoundingBox<2, std::vector>(const std::vector<AxisBox<2>, st
 
 template AxisBox<2> BoundingBox<2, std::vector>(const std::vector<Point<2>, std::allocator<Point<2> > >&);
 
-template AxisBox<2> Point<2>::boundingBox() const;
-template AxisBox<3> Point<3>::boundingBox() const;
-
 }


### PR DESCRIPTION
This will fix Mac OS X duplicate symbol error.
Its once defined in point.cpp
`template class Point<3>;`
and once in axisbox.cpp
`template AxisBox<3> Point<3>::boundingBox() const;`
